### PR TITLE
utils

### DIFF
--- a/crates/cli/src/commands/list.rs
+++ b/crates/cli/src/commands/list.rs
@@ -42,7 +42,7 @@ pub fn display_source(line_info: LineInfo) -> Result<()> {
     use std::io::{BufRead, BufReader};
     let source = BufReader::new(File::open(line_info.filepath)?);
     // In case compiler can't determine source code location. Page 151.
-    if line_info.line == Some(0) {
+    if line_info.line == Some(0) || line_info.line == None {
         return Ok(());
     }
     let range = line_info.line.map(|l| {

--- a/crates/cli/src/dwarf/format.rs
+++ b/crates/cli/src/dwarf/format.rs
@@ -96,6 +96,11 @@ pub fn format_object<'input>(
                     bytes.copy_from_slice(&memory[0..(base_type.byte_size as usize)]);
                     Ok(format!("{}({})", base_type.name, u32::from_le_bytes(bytes)))
                 }
+                "unsigned __int128" => {
+                    let mut bytes: [u8; 16] = Default::default();
+                    bytes.copy_from_slice(&memory[0..(base_type.byte_size as usize)]);
+                    Ok(format!("{}({})", base_type.name, u128::from_le_bytes(bytes)))
+                }
                 "char" => Ok(String::from_utf8(vec![memory[0]])
                     .unwrap_or("<<invalid utf8 char>>".to_string())),
                 _ => unimplemented!(),

--- a/crates/cli/src/process.rs
+++ b/crates/cli/src/process.rs
@@ -49,11 +49,15 @@ impl<D: Debugger> Process<D> {
     }
 
     pub fn run_loop(&mut self, context: command::CommandContext) -> Result<()> {
+        let mut last_line: Option<String> = None;
         while let ReadResult::Input(line) = self.interface.read_line()? {
             if !line.trim().is_empty() {
                 self.interface.add_history_unique(line.clone());
+                last_line = Some(line.clone());
+                self.dispatch_command(line, &context)?;
+            } else if let Some(last_line) = last_line.as_ref() {
+                self.dispatch_command(last_line.clone(), &context)?;
             }
-            self.dispatch_command(line, &context)?;
         }
         Ok(())
     }


### PR DESCRIPTION
- List only when line info extracted
- support `unsigned __int128`
- Repeat the previous command for empty command