### PR TITLE
Validate module before debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,6 +970,7 @@ dependencies = [
  "gimli 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linefeed 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi-validation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 wasminspect-vm = { path = "../vm" }
 wasminspect-wasi = { path = "../wasi" }
 wasmi-validation = "0.3.0"
+parity-wasm = "0.41"
 linefeed = "0.6.0"
 clap = "2.33.0"
 structopt = "0.3"

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -6,6 +6,8 @@ mod process;
 use anyhow::{anyhow, Result};
 use std::env;
 use std::io::Read;
+use wasmi_validation::{validate_module, PlainValidator};
+use parity_wasm::elements::Module;
 
 fn history_file_path() -> String {
     format!(
@@ -25,6 +27,8 @@ pub fn run_loop(file: Option<String>, init_source: Option<String>) -> Result<()>
     if let Some(file) = file {
         let mut f = ::std::fs::File::open(file)?;
         f.read_to_end(&mut buffer)?;
+        let module = Module::from_bytes(&buffer).unwrap();
+        validate_module::<PlainValidator>(&module).unwrap();
         debugger.load_module(&buffer)?;
         use dwarf::{parse_dwarf, transform_dwarf};
         let dwarf = parse_dwarf(&buffer)?;


### PR DESCRIPTION
I'm trying to debug a module that doesn't pass validation. Currently, `wasminspect` debugs modules without validation, which causes a not very useful error message for this invalid module:

```
% ./target/debug/wasminspect ~/Documents/Runtime/.build/debug/RuntimePackageTests.xctest
(wasminspect) run
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', 
src/libcore/option.rs:378:21
```

With this change, the error message at least specifies the expression that doesn't pass validation:

```
% ./target/debug/wasminspect ~/Documents/Runtime/.build/debug/RuntimePackageTests.xctest          
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: 
Error("Function #1750 reading/validation error: At instruction 
Call(28169)(@144): Trying to access parent frame stack values.")', 
src/libcore/result.rs:1165:5
```

The module is compiled from a test suite for [the Runtime library](https://github.com/MaxDesiatov/Runtime/tree/wasi-build), I've fixed a few validation errors in it already (C function declarations didn't match actual definitions in Swift runtime), but there's still something left, so I'm hoping that `swiftinspect` greatly helps with investigating the issue.

The module binary is attached:

[RuntimePackageTests.xctest.zip](https://github.com/kateinoigakukun/wasminspect/files/4566187/RuntimePackageTests.xctest.zip)
