### PR TITLE
wasmparser: bump to 0.54.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,7 +899,7 @@ dependencies = [
  "wasminspect-swift-runtime 0.2.0",
  "wasminspect-vm 0.2.0",
  "wasminspect-wasi 0.2.0",
- "wasmparser 0.51.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.54.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -912,7 +912,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmparser 0.51.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.54.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -921,12 +921,12 @@ version = "0.2.0"
 dependencies = [
  "wasi-common 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasminspect-vm 0.2.0",
- "wasmparser 0.51.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.54.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.51.4"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -951,7 +951,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasminspect-vm 0.2.0",
- "wasmparser 0.51.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.54.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wast 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1120,7 +1120,7 @@ dependencies = [
 "checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum wasi-common 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cd6d7a7b4e2450ef06f4616c349059edb76b8d6b309e1b48944f887217a5eb2f"
 "checksum wasi-common-cbindgen 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6505210d9300ff7156ada60210150d4c9a2a71900a6a4b62161038904cb4c451"
-"checksum wasmparser 0.51.4 (registry+https://github.com/rust-lang/crates.io-index)" = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
+"checksum wasmparser 0.54.0 (registry+https://github.com/rust-lang/crates.io-index)" = "747467da102640806cf6643e032a70174e7768839bcac7e71a0a9aaa54761d59"
 "checksum wast 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "233648f540f07fce9b972436f2fbcae8a750c1121b6d32d949e1a44b4d9fc7b1"
 "checksum wast 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12a729d076deb29c8509fa71f2d427729f9394f9496844ed8fcab152f35d163d"
 "checksum wig 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6da05fa60030980a9c05480d8c21aaa3639027708c6fff1b4154ee66fe4b01dd"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,7 +13,7 @@ clap = "2.33.0"
 structopt = "0.3"
 thiserror = "1.0.9"
 anyhow = "1.0.26"
-wasmparser = "0.51.4"
+wasmparser = "0.54.0"
 gimli = "0.20.0"
 log = "0.4.8"
 

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Yuta Saito <kateinoigakukun@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-wasmparser = "0.51.4"
+wasmparser = "0.54.0"
 thiserror = "1.0.9"
 anyhow = "1.0.26"

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 [dependencies]
 wasi-common = "0.8.0"
 wasminspect-vm = { path = "../vm" }
-wasmparser = "0.51.4"
+wasmparser = "0.54.0"

--- a/crates/wast-spec/Cargo.toml
+++ b/crates/wast-spec/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 wasminspect-vm = { path = "../vm" }
 wast = "7.0.0"
 anyhow = "1.0.26"
-wasmparser = "0.51.4"
+wasmparser = "0.54.0"


### PR DESCRIPTION
This is the most recent version that doesn't require code changes.

(A few "snake case" warnings did pop up. I guess I'll leave those to you :-)